### PR TITLE
entferne nicht aktuelle Zahlen für Münster am Sonntag

### DIFF
--- a/coronavirus-fallzahlen-regierungsbezirk-muenster.csv
+++ b/coronavirus-fallzahlen-regierungsbezirk-muenster.csv
@@ -17,7 +17,6 @@ Kreis Steinfurt,30.03.2020,395,90,1
 Kreis Warendorf,30.03.2020,303,98,1
 Stadt Bottrop,29.03.2020,38,10,1
 Stadt Gelsenkirchen,29.03.2020,92,4,0
-Stadt Münster,29.03.2020,443,101,2
 Kreis Borken,29.03.2020,438,75,5
 Kreis Coesfeld,29.03.2020,303,46,1
 Kreis Recklinghausen,29.03.2020,328,78,1


### PR DESCRIPTION
Am Sonntag gab es keine neuen Zahlen aus Münster, s. https://www.muenster.de/corona.html